### PR TITLE
IMPLEMENT CUSTOM DATAVIEW LANGUAGE SYNTAX HIGHLIGHTING

### DIFF
--- a/components/Image.js
+++ b/components/Image.js
@@ -1,7 +1,9 @@
-const Image = ({ src, alt, ...rest }) => (
+import Image from 'next/image'
+
+const CustomImage = ({ src, alt, ...rest }) => (
   <div className="flex justify-center">
-    <img src={src} alt={alt || 'image'} {...rest} className="mx-auto rounded-md" />{' '}
+    <Image src={src} alt={alt || 'image'} {...rest} className="mx-auto rounded-md" />
   </div>
 )
 
-export default Image
+export default CustomImage

--- a/css/prism.css
+++ b/css/prism.css
@@ -2,6 +2,21 @@ pre {
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.75);
 }
 
+input[type='checkbox']:disabled {
+  background-color: transparent;
+  border: 1px solid #31cca8;
+  border-radius: 2px;
+}
+
+input[type='checkbox']:checked {
+  background-color: #31cca8;
+  transition: all 2ms ease-in;
+}
+
+input[type='checkbox']:checked:hover {
+  background-color: #31cca8;
+}
+
 pre[class*='language-'],
 code[class*='language-'] {
   color: #dddddd;

--- a/css/prism.css
+++ b/css/prism.css
@@ -1,7 +1,4 @@
-pre {
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.75);
-}
-
+/* Checkbox styling  */
 input[type='checkbox']:disabled {
   background-color: transparent;
   border: 1px solid #31cca8;
@@ -16,11 +13,10 @@ input[type='checkbox']:checked {
 input[type='checkbox']:checked:hover {
   background-color: #31cca8;
 }
-
+/* 
 pre[class*='language-'],
 code[class*='language-'] {
   color: #dddddd;
-  font-size: 13px;
   text-shadow: none;
   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
   direction: ltr;
@@ -37,6 +33,7 @@ code[class*='language-'] {
   -ms-hyphens: none;
   hyphens: none;
 }
+
 pre[class*='language-']::selection,
 code[class*='language-']::selection,
 pre[class*='language-']::mozselection,
@@ -44,24 +41,19 @@ code[class*='language-']::mozselection {
   text-shadow: none;
   background: #14ff30;
 }
+
 @media print {
   pre[class*='language-'],
   code[class*='language-'] {
     text-shadow: none;
   }
+} */
+
+/* styles 'normal' code in codeblocks only (not inline) */
+pre[class*='language-'] > code[class*='language-'] {
+  color: #d0d0d0;
 }
-pre[class*='language-'] {
-  padding: 1em;
-  margin: 0.5em 0;
-  overflow: auto;
-  background: #262626;
-}
-:not(pre) > code[class*='language-'] {
-  padding: 0.1em 0.3em;
-  border-radius: 0.3em;
-  color: #14ff30;
-  background: #262626 !important;
-}
+
 /*********************************************************
 * Tokens
 */
@@ -75,7 +67,7 @@ pre[class*='language-'] {
   color: #777777;
 }
 .token.punctuation {
-  color: #999999;
+  color: #e0e0e0;
 }
 .token.property,
 .token.tag,
@@ -124,35 +116,4 @@ pre[class*='language-'] {
 }
 .token.entity {
   cursor: help;
-}
-/*********************************************************
-* Line highlighting
-*/
-pre[data-line] {
-  position: relative;
-}
-pre[class*='language-'] > code[class*='language-'] {
-  position: relative;
-  z-index: 1;
-}
-.line-highlight {
-  position: absolute;
-  left: 0;
-  right: 0;
-  padding: inherit 0;
-  margin-top: 1em;
-  background: #333333;
-  box-shadow: inset 5px 0 0 #14ff30;
-  z-index: 0;
-  pointer-events: none;
-  line-height: inherit;
-  white-space: pre;
-}
-
-/* Specifically targeting inline code */
-.prose :where(code):not(:where([class~='not-prose'] *)) {
-  padding: 0.1em 0.3em;
-  border-radius: 0.2em;
-  background: #262626;
-  color: #31cca8;
 }

--- a/layouts/PostSimple.js
+++ b/layouts/PostSimple.js
@@ -10,12 +10,20 @@ import { useRouter } from 'next/router'
 import LinkArrow from '@/components/LinkArrow'
 import HeaderTagList from '@/components/HeaderTagList'
 
+import { useEffect } from 'react'
+
+import Prism from 'prismjs'
+import '../lib/prism/dataview'
+
 export default function PostLayout({ frontMatter, authorDetails, next, prev, children }) {
-  console.log(frontMatter)
   const { date, title, tags } = frontMatter
 
   const router = useRouter()
   const directory = router.pathname.split('/')[1]
+
+  useEffect(() => {
+    Prism.highlightAll()
+  }, [])
 
   return (
     <SectionContainer>

--- a/lib/prism/dataview.js
+++ b/lib/prism/dataview.js
@@ -3,8 +3,8 @@ import Prism from 'prismjs'
 
 Prism.languages.dataview = {
   comment: /\/\/.*/,
-  keyword: /\b(TABLE WITHOUT ID|FROM|FLATTEN|WHERE|GROUP BY|AND|OR|this)\b/,
-  function: /\b(map|contains|econtains)\(\)/,
+  keyword: /\b(TABLE WITHOUT ID|FROM|FLATTEN|WHERE|GROUP BY|AND|OR|this|AS)\b/,
+  function: /\b\w+(?=\()/,
   operator: /=|=>|!=/,
   variable: /#[\w\/]+/,
   string: {

--- a/lib/prism/dataview.js
+++ b/lib/prism/dataview.js
@@ -6,7 +6,7 @@ Prism.languages.dataview = {
   keyword: /\b(TABLE WITHOUT ID|FROM|FLATTEN|WHERE|GROUP BY|AND|OR|this|AS)\b/,
   function: /\b\w+(?=\()/,
   operator: /=|=>|!=/,
-  variable: /#[\w\/]+/,
+  variable: /#[\w/]+/,
   string: {
     pattern: /(["'])(?:\\.|(?!\1)[^\\\r\n])*\1/,
     greedy: true,

--- a/lib/prism/dataview.js
+++ b/lib/prism/dataview.js
@@ -1,0 +1,15 @@
+// prism-dataview.js
+import Prism from 'prismjs'
+
+Prism.languages.dataview = {
+  comment: /\/\/.*/,
+  keyword: /\b(TABLE WITHOUT ID|FROM|FLATTEN|WHERE|GROUP BY|AND|OR|this)\b/,
+  function: /\b(map|contains|econtains)\(\)/,
+  operator: /=|=>|!=/,
+  variable: /#[\w\/]+/,
+  string: {
+    pattern: /(["'])(?:\\.|(?!\1)[^\\\r\n])*\1/,
+    greedy: true,
+  },
+  punctuation: /[.,()]/,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tailwind-nextjs-starter-blog",
+  "name": "darian-blog",
   "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tailwind-nextjs-starter-blog",
+      "name": "darian-blog",
       "version": "1.5.6",
       "dependencies": {
         "@fontsource/inter": "4.5.2",
@@ -26,6 +26,7 @@
         "next-themes": "^0.0.14",
         "postcss": "^8.4.5",
         "preact": "^10.6.2",
+        "prismjs": "^1.29.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "reading-time": "1.3.0",
@@ -20718,9 +20719,12 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
-      "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg=="
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -21518,15 +21522,14 @@
       "dev": true
     },
     "node_modules/refractor": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-4.3.0.tgz",
-      "integrity": "sha512-avSi9ItM6ewXJJIid5KzAgGi7AWpGatAKvQYqLFqZYZsc9klJ7IZVBZv1ocbgZANnZQOVAX46geNd3XQZxWyuw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-4.8.1.tgz",
+      "integrity": "sha512-/fk5sI0iTgFYlmVGYVew90AoYnNMP6pooClx/XKqyeeCQXrL0Kvgn8V0VEht5ccdljbzzF1i3Q213gcntkRExg==",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/prismjs": "^1.0.0",
         "hastscript": "^7.0.0",
-        "parse-entities": "^4.0.0",
-        "prismjs": "~1.25.0"
+        "parse-entities": "^4.0.0"
       },
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "next-themes": "^0.0.14",
     "postcss": "^8.4.5",
     "preact": "^10.6.2",
+    "prismjs": "^1.29.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "reading-time": "1.3.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,6 +50,7 @@ module.exports = {
         greenDark: '0 0 22px 8px rgba(5, 255, 0, .25)',
         green: '0 0 22px 8px rgba(39, 161, 133, .25)',
         yellow: '0 0 22px 8px rgba(236, 172, 69, .25)',
+        code: '0 8px 16px rgba(0, 0, 0, 0.75)',
       },
       typography: (theme) => ({
         DEFAULT: {
@@ -82,15 +83,11 @@ module.exports = {
             },
             pre: {
               backgroundColor: theme('colors.gray.800'),
+              boxShadow: theme('boxShadow.code'),
             },
             code: {
-              color: theme('colors.pink.500'),
-              backgroundColor: theme('colors.gray.100'),
-              paddingLeft: '4px',
-              paddingRight: '4px',
-              paddingTop: '2px',
-              paddingBottom: '2px',
-              borderRadius: '0.25rem',
+              backgroundColor: theme('colors.gray.200'),
+              color: theme('colors.primary.600'),
             },
             'code::before': {
               content: 'none',
@@ -161,6 +158,7 @@ module.exports = {
             },
             code: {
               backgroundColor: theme('colors.gray.800'),
+              color: theme('colors.primary.400'),
             },
             details: {
               backgroundColor: theme('colors.gray.800'),


### PR DESCRIPTION
_note: all code block syntax highlighting is utilizing the `rehype-prism-plus` library, but I was unable to extend it with a custom language definition in `mdx.js`, so this is a separate solution utilizing regular Prism.js library_
Apply custom syntax highlighting to dataview (dataview query language) which is specific to Obsidian:
- create a custom /lib/prism/dataview.js script with tokenization rules for dataview
- installed regular prismjs to access the prism object
- applied `highlightAll()` to the `PostSimple` layout
- all codeblocks in posts using the PostSimple layout will be iterated over and tokenization will be applied via Prism for dataview language